### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/LAB_01_Configure_Microsoft_Defender.md
+++ b/Instructions/Labs/LAB_01_Configure_Microsoft_Defender.md
@@ -1,8 +1,20 @@
 ---
 lab:
-    title: 'Configure Microsoft Defender'
-    module: 'Configure the Microsoft Defender XDR environment'
+  title: Configure Microsoft Defender
+  module: Configure the Microsoft Defender XDR environment
+  description: You're a Security Operations Analyst working at a company that is implementing
+    Microsoft Defender XDR. Your role is to guide the company’s IT team in defending
+    against threats with Microsoft Defender (XDR). The company’s executives are very
+    concerned that all guidelines are followed and that all requirements are met when
+    you complete the activities in their environment.
+  duration: 5 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Microsoft Defender
+  - Microsoft Defender XDR
 ---
+
 You're a Security Operations Analyst working at a company that is implementing Microsoft Defender XDR. Your role is to
 guide the company’s IT team in defending against threats with Microsoft Defender (XDR). The company’s executives are very concerned that all guidelines are followed and that all requirements are met when you complete the activities in their environment.
 

--- a/Instructions/Labs/LAB_02_Deploy_Defender_Endpoint.md
+++ b/Instructions/Labs/LAB_02_Deploy_Defender_Endpoint.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Deploy Microsoft Defender for Endpoint'
-    module: Mitigate threats using Microsoft Defender for Endpoint'
+  title: Deploy Microsoft Defender for Endpoint
+  module: Mitigate threats using Microsoft Defender for Endpoint'
+  description: You're a Security Operations Analyst working at a company that is implementing
+    Microsoft Defender for Endpoint. Your manager plans to onboard a few devices to
+    provide insight into required changes to the Security Operations (SecOps) team
+    response procedures.
+  duration: 15 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Microsoft Defender
+  - Microsoft Defender for Endpoint
 ---
 
 # Deploy Microsoft Defender for Endpoint

--- a/Instructions/Labs/LAB_03_Mitigate_Attacks.md
+++ b/Instructions/Labs/LAB_03_Mitigate_Attacks.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Mitigate Attacks with Microsoft Defender for Endpoint'
-    module: 'Mitigate threats using Microsoft Defender for Endpoint'
+  title: Mitigate Attacks with Microsoft Defender for Endpoint
+  module: Mitigate threats using Microsoft Defender for Endpoint
+  description: You are a Security Operations Analyst working at a company that is
+    implementing Microsoft Defender for Endpoint. Your manager plans to onboard a
+    few devices to provide insight into required changes to the Security Operations
+    (SecOps) team response procedures.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Microsoft Defender
+  - Microsoft Defender for Endpoint
 ---
 
 # Mitigate Attacks with Microsoft Defender for Endpoint


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/LAB_01_Configure_Microsoft_Defender.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_Deploy_Defender_Endpoint.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_03_Mitigate_Attacks.md` (description,duration,level,islab,primarytopics)
